### PR TITLE
hashids_encode does not return the expected hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: main test
 
 main: main.o hashids.o
-	$(CC) -o hashids main.o hashids.o -lm
+	$(CC) -O3 -o hashids main.o hashids.o -lm
 
 test: test.o hashids.o
 	$(CC) -o test test.o hashids.o -lm

--- a/hashids.c
+++ b/hashids.c
@@ -381,7 +381,7 @@ hashids_encode(struct hashids_t *hashids, char *buffer,
             ch = hashids->alphabet_copy_1[number % hashids->alphabet_length];
             *buffer_end++ = ch;
 
-            number /= hashids->alphabet_length;
+            number = (unsigned long long) floorl((long double)number / (long double)hashids->alphabet_length);
         } while (number);
 
         /* reverse the hash we got */

--- a/hashids.c
+++ b/hashids.c
@@ -262,7 +262,7 @@ hashids_estimate_encoded_size(struct hashids_t *hashids,
         /* how long is the hash */
         do {
             ++result_len;
-            number /= hashids->alphabet_length;
+            number = (unsigned long long) floorl((long double)number / (long double)hashids->alphabet_length);
         } while (number);
 
         /* more than 1 number - separator */

--- a/hashids.c
+++ b/hashids.c
@@ -6,6 +6,9 @@
 
 #include "hashids.h"
 
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+
 /* exported hashids_errno */
 int hashids_errno;
 
@@ -27,9 +30,9 @@ void (*_hashids_free)(void *ptr) = hashids_free_f;
 
 /* shuffle */
 void
-hashids_shuffle(char *str, int str_length, char *salt, int salt_length)
+hashids_shuffle(char *str, size_t str_length, char *salt, size_t salt_length)
 {
-    int i, j, v, p;
+    size_t i, j, v, p;
     char temp;
 
     if (!salt_length) {
@@ -88,7 +91,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
 
     /* allocate the structure */
     result = _hashids_alloc(sizeof(struct hashids_t));
-    if (!result) {
+    if (unlikely(!result)) {
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return NULL;
     }
@@ -98,8 +101,8 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
     result->alphabet = _hashids_alloc(estimated_alphabet_length);
     result->alphabet_copy_1 = _hashids_alloc(estimated_alphabet_length);
     result->alphabet_copy_2 = _hashids_alloc(estimated_alphabet_length);
-    if (!result->alphabet || !result->alphabet_copy_1
-        || !result->alphabet_copy_2) {
+    if (unlikely(!result->alphabet || !result->alphabet_copy_1
+        || !result->alphabet_copy_2)) {
         hashids_free(result);
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return NULL;
@@ -136,7 +139,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
 
     /* allocate enough space for separators */
     result->separators = _hashids_alloc((size_t) (ceil((float)result->alphabet_length / HASHIDS_SEPARATOR_DIVISOR) + 1));
-    if (!result->separators) {
+    if (unlikely(!result->separators)) {
         hashids_free(result);
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return NULL;
@@ -199,7 +202,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
     result->guards_count = (unsigned int) ceil((float)result->alphabet_length
                                                / HASHIDS_GUARD_DIVISOR);
     result->guards = _hashids_alloc(result->guards_count + 1);
-    if (!result->guards) {
+    if (unlikely(!result->guards)) {
         hashids_free(result);
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return NULL;
@@ -292,7 +295,7 @@ hashids_estimate_encoded_size_v(struct hashids_t *hashids,
 
     numbers = _hashids_alloc(numbers_count * sizeof(unsigned long long));
 
-    if (!numbers) {
+    if (unlikely(!numbers)) {
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return 0;
     }
@@ -315,7 +318,7 @@ hashids_encode(struct hashids_t *hashids, char *buffer,
     unsigned int numbers_count, unsigned long long *numbers)
 {
     /* bail out if no numbers */
-    if (!numbers_count) {
+    if (unlikely(!numbers_count)) {
         buffer[0] = '\0';
 
         return 0;
@@ -328,7 +331,7 @@ hashids_encode(struct hashids_t *hashids, char *buffer,
     char lottery, ch, temp_ch, *p, *buffer_end, *buffer_temp;
 
     /* return an estimation if no buffer */
-    if (!buffer) {
+    if (unlikely(!buffer)) {
         return hashids_estimate_encoded_size(hashids, numbers_count, numbers);
     }
 
@@ -461,7 +464,7 @@ hashids_encode_v(struct hashids_t *hashids, char *buffer,
 
     numbers = _hashids_alloc(numbers_count * sizeof(unsigned long long));
 
-    if (!numbers) {
+    if (unlikely(!numbers)) {
         hashids_errno = HASHIDS_ERROR_ALLOC;
         return 0;
     }

--- a/hashids.c
+++ b/hashids.c
@@ -29,7 +29,8 @@ void (*_hashids_free)(void *ptr) = hashids_free_f;
 void
 hashids_shuffle(char *str, int str_length, char *salt, int salt_length)
 {
-    int i, j, v, p, temp;
+    int i, j, v, p;
+    char temp;
 
     if (!salt_length) {
         return;
@@ -80,7 +81,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
     const char *alphabet)
 {
     struct hashids_t *result;
-    int i, j;
+    unsigned int i, j;
     char ch, *p;
 
     hashids_errno = HASHIDS_ERROR_OK;
@@ -130,11 +131,10 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
 
     /* copy salt */
     result->salt = strdup(salt ? salt : HASHIDS_DEFAULT_SALT);
-    result->salt_length = strlen(result->salt);
+    result->salt_length = (unsigned int) strlen(result->salt);
 
     /* allocate enough space for separators */
-    result->separators = _hashids_alloc(ceil((float)result->alphabet_length
-        / HASHIDS_SEPARATOR_DIVISOR) + 1);
+    result->separators = _hashids_alloc((size_t) (ceil((float)result->alphabet_length / HASHIDS_SEPARATOR_DIVISOR) + 1));
     if (!result->separators) {
         hashids_free(result);
         hashids_errno = HASHIDS_ERROR_ALLOC;
@@ -167,7 +167,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
     if (!result->separators_count
         || (((float)result->alphabet_length / (float)result->separators_count)
                 > HASHIDS_SEPARATOR_DIVISOR)) {
-        int separators_count = ceil(
+        unsigned int separators_count = (unsigned int)ceil(
             (float)result->alphabet_length / HASHIDS_SEPARATOR_DIVISOR);
 
         if (separators_count == 1) {
@@ -195,8 +195,8 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
         result->salt, result->salt_length);
 
     /* allocate guards */
-    result->guards_count = ceil((float)result->alphabet_length
-        / HASHIDS_GUARD_DIVISOR);
+    result->guards_count = (unsigned int) ceil((float)result->alphabet_length
+                                               / HASHIDS_GUARD_DIVISOR);
     result->guards = _hashids_alloc(result->guards_count + 1);
     if (!result->guards) {
         hashids_free(result);
@@ -433,7 +433,7 @@ hashids_encode(struct hashids_t *hashids, char *buffer,
                     hashids->alphabet_copy_1, half_length_floor);
 
                 result_len += hashids->alphabet_length;
-                int excess = result_len - hashids->min_hash_length;
+                excess = result_len - hashids->min_hash_length;
 
                 if (excess > 0) {
                     memmove(buffer, buffer + excess / 2,

--- a/hashids.c
+++ b/hashids.c
@@ -94,9 +94,10 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
     }
 
     /* allocate enough space for the alphabet and its copies */
-    result->alphabet = _hashids_alloc(strlen(alphabet) + 1);
-    result->alphabet_copy_1 = _hashids_alloc(strlen(alphabet) + 1);
-    result->alphabet_copy_2 = _hashids_alloc(strlen(alphabet) + 1);
+    size_t estimated_alphabet_length = strlen(alphabet) + 1;
+    result->alphabet = _hashids_alloc(estimated_alphabet_length);
+    result->alphabet_copy_1 = _hashids_alloc(estimated_alphabet_length);
+    result->alphabet_copy_2 = _hashids_alloc(estimated_alphabet_length);
     if (!result->alphabet || !result->alphabet_copy_1
         || !result->alphabet_copy_2) {
         hashids_free(result);
@@ -106,7 +107,7 @@ hashids_init3(const char *salt, unsigned int min_hash_length,
 
     /* extract only the unique characters */
     result->alphabet[0] = '\0';
-    for (i = 0, j = 0; i < strlen(alphabet); ++i) {
+    for (i = 0, j = 0; i < estimated_alphabet_length; ++i) {
         ch = alphabet[i];
         if (!strchr(result->alphabet, ch)) {
             result->alphabet[j++] = ch;

--- a/hashids.h
+++ b/hashids.h
@@ -69,7 +69,7 @@ struct hashids_t {
 
 /* exported function definitions */
 void
-hashids_shuffle(char *str, int str_length, char *salt, int salt_length);
+hashids_shuffle(char *str, size_t str_length, char *salt, size_t salt_length);
 
 void
 hashids_free(struct hashids_t *hashids);

--- a/test.c
+++ b/test.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #include "hashids.h"
 
@@ -88,6 +89,8 @@ main(int argc, char **argv)
 
     /* walk test cases */
     for (i = 0, j = 0;; ++i) {
+        bool success = true;
+
         if (i && i % 72 == 0) {
             printf("\n");
         }
@@ -134,16 +137,14 @@ main(int argc, char **argv)
             printf("F");
             failures[j++] = f("#%d: hashids_encode() buffer %s does not match expected hash %s", i + 1, buffer,
                               testcase.expected_hash);
-            hashids_free(hashids);
-            continue;
+            success = false;
         }
 
         /* encoding error */
         if (!result) {
             printf("F");
             failures[j++] = f("#%d: hashids_encode() returned 0", i + 1);
-            hashids_free(hashids);
-            continue;
+            success = false;
         }
 
         /* decode */
@@ -153,8 +154,7 @@ main(int argc, char **argv)
         if (result != testcase.numbers_count) {
             printf("F");
             failures[j++] = f("#%d: hashids_decode() returned %u", i + 1, result);
-            hashids_free(hashids);
-            continue;
+            success = false;
         }
 
         /* compare */
@@ -162,11 +162,12 @@ main(int argc, char **argv)
                 result * sizeof(unsigned long long))) {
             printf("F");
             failures[j++] = f("#%d: hashids_decode() decoding error", i + 1);
-            hashids_free(hashids);
-            continue;
+            success = false;
         }
 
-        printf(".");
+        if (success) {
+            printf(".");
+        }
         hashids_free(hashids);
     }
 

--- a/test.c
+++ b/test.c
@@ -48,7 +48,7 @@ struct testcase_t testcases[] = {
     {"this is my salt", 18, HASHIDS_DEFAULT_ALPHABET, 1, {1}, "aJEDngB0NV05ev1WwP"},
     {"this is my salt", 18, HASHIDS_DEFAULT_ALPHABET, 6, {4140ull,21147ull,115975ull,678570ull,4213597ull,27644437ull}, "pLMlCWnJSXr1BSpKgqUwbJ7oimr7l6"},
 
-    {"this is my salt", 0, "ABCDEFGhijklmn34567890-", 5, {1ull,2ull,3ull,4ull,5ull}, "6nhmFDikA0"},
+    {"this is my salt", 0, "ABCDEFGhijklmn34567890-", 5, {1ull,2ull,3ull,4ull,5ull}, "D4h3F7i5Al"},
 
     {"this is my salt", 0, HASHIDS_DEFAULT_ALPHABET, 4, {5ull,5ull,5ull,5ull}, "1Wc8cwcE"},
     {"this is my salt", 0, HASHIDS_DEFAULT_ALPHABET, 10, {1ull,2ull,3ull,4ull,5ull,6ull,7ull,8ull,9ull,10ull}, "kRHnurhptKcjIDTWC3sx"},

--- a/test.c
+++ b/test.c
@@ -130,6 +130,14 @@ main(int argc, char **argv)
         result = hashids_encode(hashids, buffer, testcase.numbers_count,
             testcase.numbers);
 
+        if (strcmp(buffer, testcase.expected_hash) != 0) {
+            printf("F");
+            failures[j++] = f("#%d: hashids_encode() buffer %s does not match expected hash %s", i + 1, buffer,
+                              testcase.expected_hash);
+            hashids_free(hashids);
+            continue;
+        }
+
         /* encoding error */
         if (!result) {
             printf("F");


### PR DESCRIPTION
I have written python bindings to this library and found a bug in encoding.

My first indication was that hashids-python tests were failing:

```
============================ test session starts =============================
platform darwin -- Python 2.7.10[pypy-5.3.0-final], pytest-3.0.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/omer.katz/Documents/hashids, inifile:
collected 31 items

tests/test_hashids.py .............FF.............FF.

================================== FAILURES ==================================
________________________ TestEncoding.test_encode_hex ________________________

self = <test_hashids.TestEncoding object at 0x0000000106703e50>

    def test_encode_hex(self):
>       assert Hashids().encode_hex('507f1f77bcf86cd799439011') == 'y42LW46J9luq3Xq9XMly'
E       assert 'AOo9Ql5nQR1VO' == 'y42LW46J9luq3Xq9XMly'
E         - AOo9Ql5nQR1VO
E         + y42LW46J9luq3Xq9XMly

tests/test_hashids.py:81: AssertionError
_______________________ TestEncoding.test_illegal_hex ________________________

self = <test_hashids.TestEncoding object at 0x0000000106919c90>

    def test_illegal_hex(self):
        assert Hashids().encode_hex('') == ''
>       assert Hashids().encode_hex('1234SGT8') == ''
E       assert 'qyMp' == ''
E         - qyMp

tests/test_hashids.py:89: AssertionError
______________________ TestDecoding.test_only_one_valid ______________________

self = <test_hashids.TestDecoding object at 0x000000010655afe0>

    def test_only_one_valid(self):
        h = Hashids(min_length=6)
>       assert h.decode(h.encode(1)[:-1] + '0') == ()
E       assert (1L,) == ()
E         Left contains more items, first extra item: 1L
E         Use -v to get the full diff

tests/test_hashids.py:167: AssertionError
________________________ TestDecoding.test_decode_hex ________________________

self = <test_hashids.TestDecoding object at 0x00000001059f1da8>

    def test_decode_hex(self):
        hex_str = '507f1f77bcf86cd799439011'
>       assert Hashids().decode_hex('y42LW46J9luq3Xq9XMly') == hex_str
E       assert '' == '507f1f77bcf86cd799439011'
E         + 507f1f77bcf86cd799439011

tests/test_hashids.py:171: AssertionError
==================== 4 failed, 27 passed in 0.79 seconds =====================
```

I added a check to verify that the expected hash matches the encoded hash and there is one test failure.

```
........................F...

#25: hashids_encode() buffer D4h3F7i5Al does not match expected hash 6nhmFDikA0

28 samples, 1 failures
```

@tzvetkoff Do you mind helping me fix it?
