### PR TITLE
Fixed segfault when separators count is equal to 0

### DIFF
--- a/hashids.c
+++ b/hashids.c
@@ -173,8 +173,10 @@ hashids_init3(const char *salt, size_t min_hash_length, const char *alphabet)
     result->alphabet_length -= result->separators_count;
 
     /* shuffle the separators */
-    hashids_shuffle(result->separators, result->separators_count,
-        result->salt, result->salt_length);
+    if (result->separators_count) {
+        hashids_shuffle(result->separators, result->separators_count,
+                        result->salt, result->salt_length);
+    }
 
     /* check if we have any/enough separators */
     if (!result->separators_count

--- a/test.c
+++ b/test.c
@@ -86,6 +86,9 @@ struct testcase_t testcases[] = {
     {"this is my salt", 0, "cfhistuCFHISTU+-", 1,
         {1337ull}, "+-+-++---++-"},
 
+    {"\\7ULC'", 22, "@'l*p9n]);+7>Ar(\\", 1,
+            {190126ull}, "9];r(An97\\]]\\()>7>\\)+]"},
+
     {NULL, 0, NULL, 0, {0ull}, NULL}
 };
 


### PR DESCRIPTION
Without this guard `hashids_init3()` segfaults on this particular case.
