### PR TITLE
Estimate length using logarithms

### DIFF
--- a/src/hashids.c
+++ b/src/hashids.c
@@ -280,9 +280,7 @@ hashids_estimate_encoded_size(hashids_t *hashids,
     /* minimum length checks */
     if (result_len++ < hashids->min_hash_length) {
         if (result_len++ < hashids->min_hash_length) {
-            while (result_len < hashids->min_hash_length) {
-                result_len += hashids->alphabet_length;
-            }
+          result_len += hashids->alphabet_length * (hashids->min_hash_length - result_len);
         }
     }
 

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -270,11 +270,7 @@ hashids_estimate_encoded_size(hashids_t *hashids,
         number = numbers[i];
 
         /* how long is the hash */
-        do {
-            ++result_len;
-            number /= hashids->alphabet_length;
-        } while (number);
-
+        result_len = (size_t)floor(log(number) / log(hashids->alphabet_length));
         /* more than 1 number - separator */
         if (i + 1 < numbers_count) {
             ++result_len;


### PR DESCRIPTION
I'm not sure if it's faster (we really need a benchmark suite) but it allows Clang to vectorize the loop.

Check the assembly diff:
https://www.diffchecker.com/Ga73O0D9
The original is your version. The diff is this PR.
