### PR TITLE
Fix types of variables inside hashids_estimate_encoded_size()

### DIFF
--- a/src/hashids.c
+++ b/src/hashids.c
@@ -310,7 +310,7 @@ size_t
 hashids_estimate_encoded_size(hashids_t *hashids,
     size_t numbers_count, unsigned long long *numbers)
 {
-    int i, result_len;
+    size_t i, result_len;
 
     for (i = 0, result_len = 1; i < numbers_count; ++i) {
         if (numbers[i] == 0) {


### PR DESCRIPTION
Both i and result_len should be `size_t` as they are on `hashids_estimate_encoded_size_v()`.
The method returns size_t anyway and there's no point in using integers in that place.
