### PR TITLE
hashids_estimate_encoded_size() performance improvements

### DIFF
--- a/src/hashids.c
+++ b/src/hashids.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <math.h>
+#include <limits.h>
 
 #include "hashids.h"
 
@@ -307,6 +308,34 @@ hashids_init(const char *salt)
     return hashids_init2(salt, HASHIDS_DEFAULT_MIN_HASH_LENGTH);
 }
 
+/* helper methods for hashids_estimate_encoded_size */
+const unsigned short int tab64[64] = {
+    63,  0, 58,  1, 59, 47, 53,  2,
+    60, 39, 48, 27, 54, 33, 42,  3,
+    61, 51, 37, 40, 49, 18, 28, 20,
+    55, 30, 34, 11, 43, 14, 22,  4,
+    62, 57, 46, 52, 38, 26, 32, 41,
+    50, 36, 17, 19, 29, 10, 13, 21,
+    56, 45, 25, 31, 35, 16,  9, 12,
+    44, 24, 15,  8, 23,  7,  6,  5};
+
+/* log2 for unsigned long long integers */
+inline unsigned short int log2_64(unsigned long long value)
+{
+    value |= value >> 1;
+    value |= value >> 2;
+    value |= value >> 4;
+    value |= value >> 8;
+    value |= value >> 16;
+    value |= value >> 32;
+    return tab64[((unsigned long long)((value - (value >> 1))*0x07EDD5E59A4E28C2)) >> 58];
+}
+
+/* ceil division for unsigned short integers */
+inline unsigned short int div_ceil(unsigned short int x, unsigned short int y) {
+  return x / y + (x % y != 0);
+}
+
 /* estimate buffer size (generic) */
 size_t
 hashids_estimate_encoded_size(hashids_t *hashids,
@@ -317,10 +346,10 @@ hashids_estimate_encoded_size(hashids_t *hashids,
     for (i = 0, result_len = 1; i < numbers_count; ++i) {
         if (numbers[i] == 0) {
             result_len += 2;
-        } else if (numbers[i] == 0xFFFFFFFFFFFFFFFFull) {
-            result_len += ceil(log2(numbers[i]) / log2(hashids->alphabet_length)) + 1;
+        } else if (numbers[i] == ULLONG_MAX) {
+            result_len += div_ceil(log2_64(numbers[i]), log2_64(hashids->alphabet_length)) + 1;
         } else {
-            result_len += ceil(log2(numbers[i] + 1) / log2(hashids->alphabet_length)) + 1;
+            result_len += div_ceil(log2_64(numbers[i] + 1), log2_64(hashids->alphabet_length)) + 1;
         }
     }
 

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -357,7 +357,7 @@ hashids_estimate_encoded_size(hashids_t *hashids,
         result_len = hashids->min_hash_length + 1;
     }
 
-    return result_len;
+    return result_len + 1;
 }
 
 /* estimate buffer size (variadic) */

--- a/src/test.c
+++ b/src/test.c
@@ -271,8 +271,16 @@ main(int argc, char **argv)
         }
 
         /* allocate buffer */
-        buffer = calloc(hashids_estimate_encoded_size(hashids,
-            testcase.numbers_count, testcase.numbers), 1);
+        size_t estimated_encoded_size = hashids_estimate_encoded_size(hashids,
+            testcase.numbers_count, testcase.numbers), expected_hash_length = strlen(testcase.expected_hash);
+        if (estimated_encoded_size < strlen(testcase.expected_hash)) {
+          fail = 1;
+          failures[j++] = f("#%04d: hashids_estimate_encoded_size() returned %zu\n"
+              "                        expected at least %zu", i + 1, estimated_encoded_size,
+              expected_hash_length);
+          goto test_end;
+        }
+        buffer = calloc(estimated_encoded_size, 1);
 
         if (!buffer) {
             fail = 1;


### PR DESCRIPTION
I got rid of the conversion of `numbers[i]` and `hashids->alphabet_length` to doubles and the conversion of the result from a float to an unsigned long long integer using two tricks I found on stackoverflow:
- [Fast computing of log2 for 64-bit integers](http://stackoverflow.com/questions/11376288/fast-computing-of-log2-for-64-bit-integers#answer-11398748)
- [Fast ceiling of an integer division in C / C++](http://stackoverflow.com/questions/2745074/fast-ceiling-of-an-integer-division-in-c-c#answer-14878734)

It should be faster than the equivalent floating point arithmetic. 
I also added a test that verifies that `hashids_estimate_encoded_size()` returns at least the expected hash length.
