### PR TITLE
Introduced a memory arenas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ hashids_free(hashids_t *hashids);
 ```
 
 The 'destructor'. This function disposes what you can allocate with the following 3 functions.
-You'll definetely need to call this function when you're done (un)hashing.
+You'll definitely need to call this function when you're done (un)hashing.
 
 #### hashids_init3
 
@@ -92,6 +92,33 @@ hashids_init(const char *salt);
 The same as `hashids_init2` but using `0` as `min_hash_length`.
 If you pass `NULL` for `salt` the `HASHIDS_DEFAULT_SALT` will be used (currently `""`).
 
+#### hashids_arena_free
+
+``` c
+void
+hashids_arena_free(hashids_arena_t *hashids_arena);
+```
+
+The arena 'destructor'. This function disposes of an allocated memory arena.
+
+#### hashids_arena_init
+
+``` c
+hashids_arena_t *
+hashids_arena_init(hashids_t *hashids);
+```
+
+The memory arena initializer you'll most often use. `hashids_arena_init` estimates the initial buffer size based on the minimum hash length of the `hashids` instance.
+
+#### hashids_new_arena_init
+
+``` c
+hashids_arena_t *
+hashids_new_arena_init(size_t buffer_size, size_t numbers_count);
+```
+
+Initializes a memory arena with a given buffer size and numbers count.
+
 #### hashids_estimate_encoded_size
 
 ``` c
@@ -109,6 +136,16 @@ size_t bytes_needed;
 bytes_needed = hashids_estimate_encoded_size(hashids, sizeof(numbers) / sizeof(unsigned long long), numbers);
 /* bytes_needed => 12 */
 ```
+
+#### hashids_estimate_encoded_size_arena
+
+``` c
+size_t
+hashids_estimate_encoded_size_arena(hashids_t *hashids, hashids_arena_t *hashids_arena,
+    size_t numbers_count, unsigned long long *numbers);
+```
+
+Same as `hashids_estimate_encoded_size` but also resizes the buffer in the provided memory arena if required.
 
 #### hashids_estimate_encoded_size_v
 
@@ -202,6 +239,15 @@ size_t numbers_count = hashids_numbers_count(hashids, "ADf9h9i0sQ");
 /* numbers_count => 5 */
 ```
 
+#### hashids_numbers_count_arena
+
+``` c
+size_t
+hashids_numbers_count_arena(hashids_t *hashids, hashids_arena_t *hashids_arena, char *str);
+```
+
+Same as `hashids_numbers_count`  but also resizes the numbers array in the provided memory arena if required.
+
 #### hashids_decode
 
 ``` c
@@ -274,8 +320,9 @@ Since the `hashids_init*` (and some of the `*_v`) functions are memory-dependent
 If you roll your own allocator, or for some reason you don't like external libraries calling `malloc`/`calloc`, you can redefine the memory handling functions:
 
 ``` c
-void *(*_hashids_alloc)(size_t size)    = hashids_alloc_f;
-void (*_hashids_free)(void *ptr)        = hashids_free_f;
+void *(*_hashids_alloc)(size_t size)                 = hashids_alloc_f;
+void *(*_hashids_realloc)(void *ptr, size_t size)    = _hashids_realloc_f;
+void (*_hashids_free)(void *ptr)                     = hashids_free_f;
 ```
 
 Please note that the `hashids_init*` functions (most likely) rely on zero-initialized memory.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ make
 ## Usage
 
 The C usage differs marginally than [JavaScript's](http://hashids.org/javascript/) or [Ruby's](http://hashids.org/ruby/) in the matter that nothing is done (automagically) for you.
-You'll have to manually allocate and free all memory you need for encoding/decoding.
-The library itself will only allocate the `hashids_t` structure (the _handle_) on its own.
+You'll have to use the hashids memory arena API or manually allocate and free all memory you need for encoding/decoding.
 If you want to roll your own allocator, [look here](#memory-allocation).
 
 ### API
@@ -110,6 +109,12 @@ hashids_arena_init(hashids_t *hashids);
 
 The memory arena initializer you'll most often use. `hashids_arena_init` estimates the initial buffer size based on the minimum hash length of the `hashids` instance.
 
+Example:
+
+``` c
+hashids_arena_t *hashids_arena = hashids_arena_init(hashids);
+```
+
 #### hashids_new_arena_init
 
 ``` c
@@ -118,6 +123,12 @@ hashids_new_arena_init(size_t buffer_size, size_t numbers_count);
 ```
 
 Initializes a memory arena with a given buffer size and numbers count.
+
+Example:
+
+``` c
+hashids_arena_t *hashids_arena = hashids_new_arena_init(32, 16);
+```
 
 #### hashids_estimate_encoded_size
 
@@ -146,6 +157,15 @@ hashids_estimate_encoded_size_arena(hashids_t *hashids, hashids_arena_t *hashids
 ```
 
 Same as `hashids_estimate_encoded_size` but also resizes the buffer in the provided memory arena if required.
+
+Example:
+
+``` c
+hashids_arena_t *hashids_arena = hashids_new_arena_init(10, 5);
+unsigned long long numbers[] = {1ull, 2ull, 3ull, 4ull, 5ull};
+size_t bytes_needed;
+bytes_needed = hashids_estimate_encoded_size(hashids, sizeof(numbers) / sizeof(unsigned long long), numbers);
+/* the hashids_arena->buffer now is now resized to contain 12 characters instead of 10. */
 
 #### hashids_estimate_encoded_size_v
 
@@ -247,6 +267,14 @@ hashids_numbers_count_arena(hashids_t *hashids, hashids_arena_t *hashids_arena, 
 ```
 
 Same as `hashids_numbers_count`  but also resizes the numbers array in the provided memory arena if required.
+
+Example:
+
+``` c
+hashids_arena_t *hashids_arena = hashids_new_arena_init(10, 4);
+size_t numbers_count = hashids_numbers_count_arena(hashids, "ADf9h9i0sQ");
+/* the hashids_arena->numbers array now is now resized to contain 5 unsigned long long integers instead of 4. */
+```
 
 #### hashids_decode
 

--- a/src/hashids.h
+++ b/src/hashids.h
@@ -65,6 +65,16 @@ struct hashids_s {
 };
 typedef struct hashids_s hashids_t;
 
+struct hashids_arena_s {
+    char *buffer;
+    size_t buffer_size;
+
+    unsigned long long *numbers;
+    size_t numbers_count;
+};
+
+typedef struct hashids_arena_s hashids_arena_t;
+
 /* exported function definitions */
 void
 hashids_shuffle(char *str, size_t str_length, char *salt, size_t salt_length);
@@ -82,9 +92,23 @@ hashids_init2(const char *salt, size_t min_hash_length);
 hashids_t *
 hashids_init(const char *salt);
 
+void
+hashids_arena_free(hashids_arena_t *hashids_arena);
+
+hashids_arena_t *
+hashids_arena_init(hashids_t *hashids);
+
+hashids_arena_t *
+hashids_new_arena_init(size_t buffer_size, size_t numbers_count);
+
 size_t
 hashids_estimate_encoded_size(hashids_t *hashids,
     size_t numbers_count, unsigned long long *numbers);
+
+size_t
+hashids_estimate_encoded_size_arena(hashids_t *hashids, hashids_arena_t *hashids_arena,
+    size_t numbers_count, unsigned long long *numbers);
+
 
 size_t
 hashids_estimate_encoded_size_v(hashids_t *hashids,
@@ -104,6 +128,9 @@ hashids_encode_one(hashids_t *hashids, char *buffer,
 
 size_t
 hashids_numbers_count(hashids_t *hashids, char *str);
+
+size_t
+hashids_numbers_count_arena(hashids_t *hashids, hashids_arena_t *hashids_arena, char *str);
 
 size_t
 hashids_decode(hashids_t *hashids, char *str,

--- a/src/test.c
+++ b/src/test.c
@@ -146,11 +146,18 @@ int
 main(int argc, char **argv)
 {
     hashids_t *hashids;
-    char *buffer;
+    hashids_arena_t *hashids_arena = NULL;
+    hashids_arena_t *hashids_global_arena = hashids_new_arena_init(1, 1); // Too small on purpose
+    char *buffer = NULL;
     size_t i, j, result;
     unsigned long long numbers[16];
     struct testcase_t testcase;
     int fail;
+
+    if (!hashids_global_arena) {
+      printf("Could not allocate global arena. Exiting...");
+      return 1;
+    }
 
     /* walk test cases */
     for (i = 0, j = 0;; ++i) {
@@ -197,6 +204,15 @@ main(int argc, char **argv)
             goto test_end;
         }
 
+        hashids_arena = hashids_arena_init(hashids);
+
+        if (!hashids_arena) {
+          fail = 1;
+          failures[j++] = f("#%04d: hashids_arena_init(): "
+              "memory allocation failed", i + 1);
+          goto test_end;
+        }
+
         /* allocate buffer */
         buffer = calloc(hashids_estimate_encoded_size(hashids,
             testcase.numbers_count, testcase.numbers), 1);
@@ -227,6 +243,50 @@ main(int argc, char **argv)
             goto test_end;
         }
 
+        /* encode with an arena */
+        hashids_estimate_encoded_size_arena(hashids, hashids_arena, testcase.numbers_count,
+            testcase.numbers);
+        result = hashids_encode(hashids, hashids_arena->buffer, testcase.numbers_count,
+            testcase.numbers);
+
+        /* encoding error */
+        if (!result) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_encode() using an arena returned 0", i + 1);
+            goto test_end;
+        }
+
+        /* compare encoded string */
+        if (strcmp(hashids_arena->buffer, testcase.expected_hash) != 0) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_encode() using an arena returned \"%s\"\n"
+                "                        expected \"%s\"", i + 1, buffer,
+                testcase.expected_hash);
+            goto test_end;
+        }
+
+        /* encode with a global arena */
+        hashids_estimate_encoded_size_arena(hashids, hashids_global_arena, testcase.numbers_count,
+            testcase.numbers);
+        result = hashids_encode(hashids, hashids_global_arena->buffer, testcase.numbers_count,
+            testcase.numbers);
+
+        /* encoding error */
+        if (!result) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_encode() using a global arena returned 0", i + 1);
+            goto test_end;
+        }
+
+        /* compare encoded string */
+        if (strcmp(hashids_global_arena->buffer, testcase.expected_hash) != 0) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_encode() using a global arena returned \"%s\"\n"
+                "                        expected \"%s\"", i + 1, buffer,
+                testcase.expected_hash);
+            goto test_end;
+        }
+
         /* decode */
         result = hashids_decode(hashids, buffer, numbers);
 
@@ -247,6 +307,48 @@ main(int argc, char **argv)
             goto test_end;
         }
 
+        /* decode using an arena */
+        hashids_numbers_count_arena(hashids, hashids_arena, buffer);
+        result = hashids_decode(hashids, buffer, hashids_arena->numbers);
+
+        /* decoding error */
+        if (result != testcase.numbers_count) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_decode() using an arena returned %u\n"
+                "                        expected %u", i + 1, result,
+                testcase.numbers_count);
+            goto test_end;
+        }
+
+        /* compare decoded numbers */
+        if (memcmp(hashids_arena->numbers, testcase.numbers,
+                result * sizeof(unsigned long long))) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_decode() using an arena decoding error", i + 1);
+            goto test_end;
+        }
+
+        /* decode using a global arena */
+        hashids_numbers_count_arena(hashids, hashids_global_arena, buffer);
+        result = hashids_decode(hashids, buffer, hashids_global_arena->numbers);
+
+        /* decoding error */
+        if (result != testcase.numbers_count) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_decode() using a global arena returned %u\n"
+                "                        expected %u", i + 1, result,
+                testcase.numbers_count);
+            goto test_end;
+        }
+
+        /* compare decoded numbers */
+        if (memcmp(hashids_global_arena->numbers, testcase.numbers,
+                result * sizeof(unsigned long long))) {
+            fail = 1;
+            failures[j++] = f("#%04d: hashids_decode() using a global arena decoding error", i + 1);
+            goto test_end;
+        }
+
 test_end:
         fputc(fail ? 'F' : '.', stdout);
 
@@ -254,11 +356,17 @@ test_end:
             hashids_free(hashids);
             hashids = NULL;
         }
+        if (hashids_arena) {
+          hashids_arena_free(hashids_arena);
+          hashids_arena = NULL;
+        }
         if (buffer) {
             free(buffer);
             buffer = NULL;
         }
     }
+
+  hashids_arena_free(hashids_global_arena);
 
     printf("\n\n");
 
@@ -271,7 +379,7 @@ test_end:
         printf("\n");
     }
 
-    printf("%lu samples, %lu failures\n", lengthof(testcases) - 1, j);
+    printf("%lu samples, %lu failures\n", lengthof(testcases), j);
 
     return j ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
This API has two benefits:
1.  The user doesn't have manage memory on his own anymore.
2. Repeated allocations and deallocations are not required since we allocate enough characters in the buffer that will fit at least minimum hash size and 16 numbers which is enough for the average case.

It's useful to me since I'll be able to save a lot of allocations in my Python bindings to this library.
