### PR TITLE
fix *__hashids_errno_addr prototype

### DIFF
--- a/src/hashids.h
+++ b/src/hashids.h
@@ -41,7 +41,7 @@
 #define HASHIDS_ERROR_INVALID_NUMBER    -5
 
 /* thread-safe hashids_errno indirection */
-extern int *__hashids_errno_addr();
+extern int *__hashids_errno_addr(void);
 #define hashids_errno (*__hashids_errno_addr())
 
 /* alloc & free */


### PR DESCRIPTION
Resolves clang note: 

` note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function`