### PR TITLE
Do not return result if decode in invalid

### DIFF
--- a/src/hashids.c
+++ b/src/hashids.c
@@ -100,8 +100,11 @@ hashids_log2_64(unsigned long long x)
 void
 _hashids_clear_numbers(unsigned long long *numbers, size_t numbers_count)
 {
-  hashids_errno = HASHIDS_ERROR_INVALID_HASH;
-  memset(numbers, 0, sizeof(unsigned long long) * numbers_count);
+    hashids_errno = HASHIDS_ERROR_INVALID_HASH;
+
+    for (unsigned int i = 0; i < numbers_count; i++) {
+        *(numbers + i) = 0;
+    }
 }
 
 /* consistent shuffle */
@@ -733,8 +736,8 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
 
             /* check limit */
             if (++numbers_count >= numbers_max) {
-              hashids_errno = HASHIDS_ERROR_INVALID_NUMBER;
-              return numbers_count + 1;
+                hashids_errno = HASHIDS_ERROR_INVALID_NUMBER;
+                return numbers_count + 1;
             }
 
             number = 0;
@@ -768,22 +771,21 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
     size_t len = str - str_start;
     str_cpy = hashids_alloc_f(len);
     if (str_cpy == NULL) {
-      hashids_free_f(str_cpy);
-      _hashids_clear_numbers(numbers_start, numbers_count);
-      return 0;
+        hashids_free_f(str_cpy);
+        _hashids_clear_numbers(numbers_start, numbers_count);
+        return 0;
     }
-
-    size_t n_encode = hashids_encode(hashids, str_cpy, numbers_count, numbers);
+    size_t n_encode = hashids_encode(hashids, str_cpy, numbers_count, numbers_start);
     if (n_encode == 0) {
-      hashids_free_f(str_cpy);
-      _hashids_clear_numbers(numbers_start, numbers_count);
-      return 0;
+        hashids_free_f(str_cpy);
+        _hashids_clear_numbers(numbers_start, numbers_count);
+        return 0;
     }
 
     if (strncmp(str_start, str_cpy, len) != 0) {
-      hashids_free_f(str_cpy);
-      _hashids_clear_numbers(numbers_start, numbers_count);
-      return 0;
+        hashids_free_f(str_cpy);
+        _hashids_clear_numbers(numbers_start, numbers_count);
+        return 0;
     }
 
     return numbers_count;

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -675,12 +675,9 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
     size_t numbers_max)
 {
     size_t numbers_count;
-    unsigned long long number, *numbers_start;
-    char lottery, ch, *p, *c, *str_cpy, *str_start;
+    unsigned long long number;
+    char lottery, ch, *p, *c;
     int p_max;
-
-    str_start = str;
-    numbers_start = numbers;
 
     if (!numbers || !numbers_max) {
         return hashids_numbers_count(hashids, str);
@@ -767,9 +764,21 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
     /* store last number */
     *numbers = number;
 
-    /* Encode output to make sure it's the same as input */
-    numbers_count++;
+    return numbers_count + 1;
+}
 
+/* decode and verify salt */
+size_t
+hashids_decode_verify_salt(hashids_t *hashids, char *str, unsigned long long *numbers,
+    size_t numbers_max)
+{
+    unsigned long long *numbers_start;
+    char *str_cpy, *str_start;
+
+    str_start = str;
+    numbers_start = numbers;
+
+    size_t numbers_count = hashids_decode(hashids, str, numbers, numbers_max);
     size_t len = hashids_estimate_encoded_size(hashids, numbers_count, numbers_start);
     str_cpy = hashids_alloc_f(len);
     if (str_cpy == NULL) {
@@ -792,6 +801,7 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
 
     return numbers_count;
 }
+
 
 /* unsafe decode */
 size_t

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -768,13 +768,14 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
 
     /* Encode output to make sure it's the same as input */
     numbers_count++;
-    size_t len = str - str_start;
+
+    size_t len = hashids_estimate_encoded_size(hashids, numbers_count, numbers_start);
     str_cpy = hashids_alloc_f(len);
     if (str_cpy == NULL) {
-        hashids_free_f(str_cpy);
         _hashids_clear_numbers(numbers_start, numbers_count);
         return 0;
     }
+
     size_t n_encode = hashids_encode(hashids, str_cpy, numbers_count, numbers_start);
     if (n_encode == 0) {
         hashids_free_f(str_cpy);

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -734,8 +734,7 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
 
             /* check limit */
             if (++numbers_count >= numbers_max) {
-                hashids_errno = HASHIDS_ERROR_INVALID_NUMBER;
-                return numbers_count + 1;
+                return numbers_count;
             }
 
             number = 0;

--- a/src/hashids.c
+++ b/src/hashids.c
@@ -102,7 +102,8 @@ _hashids_clear_numbers(unsigned long long *numbers, size_t numbers_count)
 {
     hashids_errno = HASHIDS_ERROR_INVALID_HASH;
 
-    for (unsigned int i = 0; i < numbers_count; i++) {
+    unsigned int i;
+    for (i = 0; i < numbers_count; i++) {
         *(numbers + i) = 0;
     }
 }

--- a/src/hashids.h
+++ b/src/hashids.h
@@ -111,6 +111,10 @@ hashids_decode(hashids_t *hashids, char *str, unsigned long long *numbers,
     size_t numbers_max);
 
 size_t
+hashids_decode_verify_salt(hashids_t *hashids, char *str, unsigned long long *numbers,
+    size_t numbers_max);
+
+size_t
 hashids_decode_unsafe(hashids_t *hashids, char *str, unsigned long long *numbers);
 
 size_t

--- a/src/test.c
+++ b/src/test.c
@@ -363,6 +363,28 @@ main(int argc, char **argv)
             goto test_end;  /* nop? */
         }
 
+        /* decode and verify salt */
+        result = hashids_decode_verify_salt(hashids, buffer, numbers, 16);
+
+        /* decoding error */
+        if (result != testcase.numbers_count) {
+            fail = 1;
+            failures[k++] = f("%s:%d: hashids_decode_verify_salt() "
+                "returned %u, expected %u",
+                __FILE__, testcase.line,
+                result, testcase.numbers_count);
+            goto test_end;
+        }
+
+        /* compare decoded numbers */
+        if (memcmp(numbers, testcase.numbers,
+                result * sizeof(unsigned long long))) {
+            fail = 1;
+            failures[k++] = f("%s:%d: hashids_decode_verify_salt() decoding error",
+                __FILE__, testcase.line);
+            goto test_end;  /* nop? */
+        }
+
 test_end:
         fputc(fail ? 'F' : '.', stdout);
 


### PR DESCRIPTION
If the salt is invalid set the numbers to 0 and `hashids_errno = HASHIDS_ERROR_INVALID_HASH`.

This is done by encode the result of the decode and match the against the origin hash.
Just like the JS lib does: https://github.com/ivanakimov/hashids.js/blob/73bd48dab54476bc6fb46d1da67d0697c2e366ce/lib/hashids.js#L262